### PR TITLE
Demonstrating liquidmetal failure.

### DIFF
--- a/tests/test_score_bounds.py
+++ b/tests/test_score_bounds.py
@@ -1,0 +1,12 @@
+from hypothesis import given, settings
+import hypothesis.strategies as st
+
+import stringscore.liquidmetal as lm
+
+
+@given(st.text(), st.text())
+@settings(max_examples=50000)
+def test_score_boundaries(string, abbrev):
+    score = lm.score(string, abbrev)
+    assert score >= 0.0
+    assert score <= 1.0

--- a/tests/test_stringscore.py
+++ b/tests/test_stringscore.py
@@ -16,6 +16,9 @@ from stringscore import quicksilver
 
 class LiquidMetalTestCase(unittest.TestCase):
 
+    def test_index_failure(self):
+        liquidmetal.score('İ', 'İ')
+
     def test_score(self):
         n = liquidmetal.SCORE_NO_MATCH
         m = liquidmetal.SCORE_MATCH


### PR DESCRIPTION
This isn't really a pull-request per se. I think I've found a bug in `liquidmetal.score`, and this seemed like the simplest way to communicate it. 

Short version: `liquidmetal.score` throws an `IndexError` for some inputs. I added the test `LiquidMetalTestCase.test_index_failure` to demonstrate one set of inputs that causes the failure.

I initially discovered this bug because the [travis-ci tests for one of my projects was failing](https://travis-ci.org/abingham/decktape.io/builds/163624567). I couldn't initially reproduce the problem on my local machine, but I was able to use [hypothesis](http://hypothesis.works/) to find some inputs that broke the function. I've included that test in `test_score_bounds.py`. (BTW, I'm a big fan of hypothesis, and I think your project is a great candidate for it.)

FWIW, I've only seen this fail when non-ASCII characters are involved, so maybe that's a clue.
